### PR TITLE
add centered boolean to the centerable content sections

### DIFF
--- a/src/modules/content/elements/Accordion/SectionAccordion.vue
+++ b/src/modules/content/elements/Accordion/SectionAccordion.vue
@@ -23,6 +23,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             headline: '',
+            centered: false,
             items: [],
         }),
     },

--- a/src/modules/content/elements/Accordion/SectionAccordionForm.vue
+++ b/src/modules/content/elements/Accordion/SectionAccordionForm.vue
@@ -1,5 +1,6 @@
 <template>
-    <Card class="mb-3">
+    <Card class="flex flex-col gap-8 mb-3">
+        <Toggle v-model="model.centered" label="Content zentrieren" />
         <Input v-model="model.headline" label="Überschrift" />
     </Card>
     <div class="pb-6 space-y-3">
@@ -43,7 +44,7 @@
                     </Header>
                     <div class="col-span-6 space-y-4">
                         <Input v-model="element.title" label="Title" />
-                        <Textarea v-model="element.text" label="Text" />
+                        <Wysiwyg v-model="element.text" label="Text" />
                     </div>
                 </Card>
             </template>
@@ -62,8 +63,9 @@ import {
     Card,
     InteractionButton,
     Input,
-    Textarea,
+    Wysiwyg,
     Header,
+    Toggle,
     ContextMenu,
     ContextMenuItem,
 } from '@/ui';
@@ -80,6 +82,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             headline: '',
+            centered: false,
             items: [],
         }),
     },
@@ -87,6 +90,7 @@ const props = defineProps({
 
 const model = reactive({
     headline: props.modelValue.headline,
+    centered: props.modelValue.centered,
     items: props.modelValue.items.map((item: any) => {
         return { ...item, _draggableKey: uuid() };
     }),

--- a/src/modules/content/elements/CTA/SectionCTA.vue
+++ b/src/modules/content/elements/CTA/SectionCTA.vue
@@ -23,6 +23,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             important: false,
+            centered: false,
             link: {
                 link: '',
                 text: '',

--- a/src/modules/content/elements/CTA/SectionCTAForm.vue
+++ b/src/modules/content/elements/CTA/SectionCTAForm.vue
@@ -1,6 +1,7 @@
 <template>
     <Card>
         <FormGroup>
+            <Toggle v-model="model.centered" label="Content zentrieren" />
             <Link v-model="model.link" />
             <div>
                 <Toggle
@@ -29,6 +30,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             important: false,
+            centered: false,
             link: {
                 link: '',
                 text: '',

--- a/src/modules/content/elements/H2/SectionH2.vue
+++ b/src/modules/content/elements/H2/SectionH2.vue
@@ -23,6 +23,7 @@ defineProps({
         required: true,
         default: () => ({
             text: '',
+            centered: false,
         }),
     },
 });

--- a/src/modules/content/elements/H2/SectionH2Form.vue
+++ b/src/modules/content/elements/H2/SectionH2Form.vue
@@ -1,10 +1,11 @@
 <template>
-    <Card class="mb-3">
+    <Card class="flex flex-col gap-8 mb-3">
+        <Toggle v-model="model.centered" label="Content zentrieren" />
         <Input v-model="model.text" label="H2 Überschrift" />
     </Card>
 </template>
 <script setup lang="ts">
-import { Card, Input } from '@/ui';
+import { Card, Toggle, Input } from '@/ui';
 
 import { watch, reactive } from 'vue';
 
@@ -16,6 +17,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             text: '',
+            centered: false,
         }),
     },
 });

--- a/src/modules/content/elements/ImageSmall/SectionImageSmall.vue
+++ b/src/modules/content/elements/ImageSmall/SectionImageSmall.vue
@@ -22,6 +22,7 @@ const props = defineProps({
         type: Object,
         required: true,
         default: () => ({
+            centered: false,
             image: {
                 id: null,
                 title: '',

--- a/src/modules/content/elements/ImageSmall/SectionImageSmallForm.vue
+++ b/src/modules/content/elements/ImageSmall/SectionImageSmallForm.vue
@@ -1,10 +1,13 @@
 <template>
     <FormFieldLabel> Bild </FormFieldLabel>
+    <Card class="mb-6">
+        <Toggle v-model="model.centered" label="Content zentrieren" />
+    </Card>
     <SelectImage v-model="model.image" />
 </template>
 <script setup lang="ts">
 import SelectImage from '@/modules/media/SelectImage.vue';
-import { FormFieldLabel } from '@/ui';
+import { FormFieldLabel, Toggle, Card } from '@/ui';
 
 import { watch, reactive } from 'vue';
 
@@ -15,6 +18,7 @@ const props = defineProps({
         type: Object,
         required: true,
         default: () => ({
+            centered: false,
             image: {
                 id: null,
                 title: '',

--- a/src/modules/content/elements/InfoBox/SectionInfoBox.vue
+++ b/src/modules/content/elements/InfoBox/SectionInfoBox.vue
@@ -24,6 +24,7 @@ const props = defineProps({
         default: () => ({
             title: '',
             text: '',
+            centered: false,
             link: {
                 link: '',
                 text: '',

--- a/src/modules/content/elements/InfoBox/SectionInfoBoxForm.vue
+++ b/src/modules/content/elements/InfoBox/SectionInfoBoxForm.vue
@@ -1,6 +1,7 @@
 <template>
     <Card>
         <FormGroup>
+            <Toggle v-model="model.centered" label="Content zentrieren" />
             <Input v-model="model.title" class="w-full" label="Titel" />
             <Textarea v-model="model.text" class="w-full" label="Text" />
             <Link v-model="model.link" />
@@ -8,7 +9,7 @@
     </Card>
 </template>
 <script setup lang="ts">
-import { Card, Input, FormGroup, Textarea } from '@/ui';
+import { Card, Input, FormGroup, Toggle, Textarea } from '@/ui';
 import Link from '@/modules/link/Link.vue';
 
 import { watch, reactive } from 'vue';
@@ -22,6 +23,7 @@ const props = defineProps({
         default: () => ({
             title: '',
             text: '',
+            centered: false,
             link: {
                 link: '',
                 text: '',

--- a/src/modules/content/elements/TextFull/SectionTextFull.vue
+++ b/src/modules/content/elements/TextFull/SectionTextFull.vue
@@ -22,6 +22,7 @@ const props = defineProps({
         type: Object,
         required: true,
         default: () => ({
+            centered: false,
             text: '',
         }),
     },

--- a/src/modules/content/elements/TextFull/SectionTextFullForm.vue
+++ b/src/modules/content/elements/TextFull/SectionTextFullForm.vue
@@ -1,10 +1,11 @@
 <template>
-    <Card>
+    <Card class="flex flex-col gap-6">
+        <Toggle v-model="model.centered" label="Content zentrieren" />
         <Wysiwyg v-model="model.text" class="w-full" />
     </Card>
 </template>
 <script setup lang="ts">
-import { Card, Wysiwyg } from '@/ui';
+import { Card, Wysiwyg, Toggle } from '@/ui';
 import { watch, reactive } from 'vue';
 
 const emit = defineEmits(['update:modelValue']);
@@ -14,6 +15,7 @@ const props = defineProps({
         type: Object,
         required: true,
         default: () => ({
+            centered: false,
             text: '',
         }),
     },

--- a/src/modules/content/elements/TextImage/SectionTextImage.vue
+++ b/src/modules/content/elements/TextImage/SectionTextImage.vue
@@ -23,6 +23,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             text: '',
+            centered: false,
             image: {
                 id: null,
                 title: '',

--- a/src/modules/content/elements/TextImage/SectionTextImageForm.vue
+++ b/src/modules/content/elements/TextImage/SectionTextImageForm.vue
@@ -1,5 +1,10 @@
 <template>
     <Card>
+        <Toggle
+            class="mb-6"
+            v-model="model.centered"
+            label="Content zentrieren"
+        />
         <div class="grid grid-cols-2 gap-5">
             <div class="col-span-1">
                 <FormFieldLabel> Text </FormFieldLabel>
@@ -23,14 +28,7 @@
     </Card>
 </template>
 <script setup lang="ts">
-import {
-    Card,
-    Input,
-    FormGroup,
-    Textarea,
-    Wysiwyg,
-    FormFieldLabel,
-} from '@/ui';
+import { Card, Input, FormGroup, Toggle, Wysiwyg, FormFieldLabel } from '@/ui';
 import SelectImage from '@/modules/media/SelectImage.vue';
 import Link from '@/modules/link/Link.vue';
 
@@ -44,6 +42,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             text: '',
+            centered: false,
             image: {
                 id: null,
                 title: '',

--- a/src/modules/content/elements/VideoEmbed/SectionVideoEmbed.vue
+++ b/src/modules/content/elements/VideoEmbed/SectionVideoEmbed.vue
@@ -23,6 +23,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             id: '',
+            centered: false,
         }),
     },
 });

--- a/src/modules/content/elements/VideoEmbed/SectionVideoEmbedForm.vue
+++ b/src/modules/content/elements/VideoEmbed/SectionVideoEmbedForm.vue
@@ -1,9 +1,12 @@
 <template>
     <FormFieldLabel>Vimeo-ID</FormFieldLabel>
-    <Input v-model="model.id" label="Vimeo-ID" />
+    <Card class="flex flex-col gap-6">
+        <Toggle v-model="model.centered" label="Content zentrieren" />
+        <Input v-model="model.id" label="Vimeo-ID" />
+    </Card>
 </template>
 <script setup lang="ts">
-import { FormFieldLabel, Input } from '@/ui';
+import { FormFieldLabel, Input, Card, Toggle } from '@/ui';
 
 import { watch, reactive, computed } from 'vue';
 
@@ -15,6 +18,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             id: '',
+            centered: false,
         }),
     },
 });


### PR DESCRIPTION
This PR adds a centered boolean to all content sections that do not cover the entire page or container width but rather have a restricted content width. This Boolean when activated will center the content in the frontend on the page, by default the sections will be on the left side.