### PR TITLE
Fix/content width boolean

### DIFF
--- a/src/modules/content/elements/Accordion/SectionAccordion.vue
+++ b/src/modules/content/elements/Accordion/SectionAccordion.vue
@@ -23,7 +23,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             headline: '',
-            centered: false,
+            content_wide: false,
             items: [],
         }),
     },

--- a/src/modules/content/elements/Accordion/SectionAccordionForm.vue
+++ b/src/modules/content/elements/Accordion/SectionAccordionForm.vue
@@ -1,6 +1,6 @@
 <template>
     <Card class="flex flex-col gap-8 mb-3">
-        <Toggle v-model="model.centered" label="Content zentrieren" />
+        <Toggle v-model="model.content_wide" label="Ganze Containerbreite" />
         <Input v-model="model.headline" label="Überschrift" />
     </Card>
     <div class="pb-6 space-y-3">
@@ -82,7 +82,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             headline: '',
-            centered: false,
+            content_wide: false,
             items: [],
         }),
     },
@@ -90,7 +90,7 @@ const props = defineProps({
 
 const model = reactive({
     headline: props.modelValue.headline,
-    centered: props.modelValue.centered,
+    content_wide: props.modelValue.content_wide,
     items: props.modelValue.items.map((item: any) => {
         return { ...item, _draggableKey: uuid() };
     }),

--- a/src/modules/content/elements/CTA/SectionCTA.vue
+++ b/src/modules/content/elements/CTA/SectionCTA.vue
@@ -23,7 +23,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             important: false,
-            centered: false,
+            content_wide: false,
             link: {
                 link: '',
                 text: '',

--- a/src/modules/content/elements/CTA/SectionCTAForm.vue
+++ b/src/modules/content/elements/CTA/SectionCTAForm.vue
@@ -1,7 +1,10 @@
 <template>
     <Card>
         <FormGroup>
-            <Toggle v-model="model.centered" label="Content zentrieren" />
+            <Toggle
+                v-model="model.content_wide"
+                label="Ganze Containerbreite"
+            />
             <Link v-model="model.link" />
             <div>
                 <Toggle
@@ -30,7 +33,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             important: false,
-            centered: false,
+            content_wide: false,
             link: {
                 link: '',
                 text: '',

--- a/src/modules/content/elements/H2/SectionH2.vue
+++ b/src/modules/content/elements/H2/SectionH2.vue
@@ -23,7 +23,7 @@ defineProps({
         required: true,
         default: () => ({
             text: '',
-            centered: false,
+            content_wide: false,
         }),
     },
 });

--- a/src/modules/content/elements/H2/SectionH2Form.vue
+++ b/src/modules/content/elements/H2/SectionH2Form.vue
@@ -1,6 +1,6 @@
 <template>
     <Card class="flex flex-col gap-8 mb-3">
-        <Toggle v-model="model.centered" label="Content zentrieren" />
+        <Toggle v-model="model.content_wide" label="Ganze Containerbreite" />
         <Input v-model="model.text" label="H2 Überschrift" />
     </Card>
 </template>
@@ -17,7 +17,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             text: '',
-            centered: false,
+            content_wide: false,
         }),
     },
 });

--- a/src/modules/content/elements/ImageSmall/SectionImageSmall.vue
+++ b/src/modules/content/elements/ImageSmall/SectionImageSmall.vue
@@ -22,7 +22,7 @@ const props = defineProps({
         type: Object,
         required: true,
         default: () => ({
-            centered: false,
+            content_wide: false,
             image: {
                 id: null,
                 title: '',

--- a/src/modules/content/elements/ImageSmall/SectionImageSmallForm.vue
+++ b/src/modules/content/elements/ImageSmall/SectionImageSmallForm.vue
@@ -1,7 +1,7 @@
 <template>
     <FormFieldLabel> Bild </FormFieldLabel>
     <Card class="mb-6">
-        <Toggle v-model="model.centered" label="Content zentrieren" />
+        <Toggle v-model="model.content_wide" label="Ganze Containerbreite" />
     </Card>
     <SelectImage v-model="model.image" />
 </template>
@@ -18,7 +18,7 @@ const props = defineProps({
         type: Object,
         required: true,
         default: () => ({
-            centered: false,
+            content_wide: false,
             image: {
                 id: null,
                 title: '',

--- a/src/modules/content/elements/InfoBox/SectionInfoBox.vue
+++ b/src/modules/content/elements/InfoBox/SectionInfoBox.vue
@@ -24,7 +24,7 @@ const props = defineProps({
         default: () => ({
             title: '',
             text: '',
-            centered: false,
+            content_wide: false,
             link: {
                 link: '',
                 text: '',

--- a/src/modules/content/elements/InfoBox/SectionInfoBoxForm.vue
+++ b/src/modules/content/elements/InfoBox/SectionInfoBoxForm.vue
@@ -1,7 +1,10 @@
 <template>
     <Card>
         <FormGroup>
-            <Toggle v-model="model.centered" label="Content zentrieren" />
+            <Toggle
+                v-model="model.content_wide"
+                label="Ganze Containerbreite"
+            />
             <Input v-model="model.title" class="w-full" label="Titel" />
             <Textarea v-model="model.text" class="w-full" label="Text" />
             <Link v-model="model.link" />
@@ -23,7 +26,7 @@ const props = defineProps({
         default: () => ({
             title: '',
             text: '',
-            centered: false,
+            content_wide: false,
             link: {
                 link: '',
                 text: '',

--- a/src/modules/content/elements/TextFull/SectionTextFull.vue
+++ b/src/modules/content/elements/TextFull/SectionTextFull.vue
@@ -22,7 +22,7 @@ const props = defineProps({
         type: Object,
         required: true,
         default: () => ({
-            centered: false,
+            content_wide: false,
             text: '',
         }),
     },

--- a/src/modules/content/elements/TextFull/SectionTextFullForm.vue
+++ b/src/modules/content/elements/TextFull/SectionTextFullForm.vue
@@ -1,6 +1,6 @@
 <template>
     <Card class="flex flex-col gap-6">
-        <Toggle v-model="model.centered" label="Content zentrieren" />
+        <Toggle v-model="model.content_wide" label="Ganze Containerbreite" />
         <Wysiwyg v-model="model.text" class="w-full" />
     </Card>
 </template>
@@ -15,7 +15,7 @@ const props = defineProps({
         type: Object,
         required: true,
         default: () => ({
-            centered: false,
+            content_wide: false,
             text: '',
         }),
     },

--- a/src/modules/content/elements/TextImage/SectionTextImage.vue
+++ b/src/modules/content/elements/TextImage/SectionTextImage.vue
@@ -23,7 +23,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             text: '',
-            centered: false,
+            content_wide: false,
             image: {
                 id: null,
                 title: '',

--- a/src/modules/content/elements/TextImage/SectionTextImageForm.vue
+++ b/src/modules/content/elements/TextImage/SectionTextImageForm.vue
@@ -2,8 +2,8 @@
     <Card>
         <Toggle
             class="mb-6"
-            v-model="model.centered"
-            label="Content zentrieren"
+            v-model="model.content_wide"
+            label="Ganze Containerbreite"
         />
         <div class="grid grid-cols-2 gap-5">
             <div class="col-span-1">
@@ -42,7 +42,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             text: '',
-            centered: false,
+            content_wide: false,
             image: {
                 id: null,
                 title: '',

--- a/src/modules/content/elements/VideoEmbed/SectionVideoEmbed.vue
+++ b/src/modules/content/elements/VideoEmbed/SectionVideoEmbed.vue
@@ -23,7 +23,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             id: '',
-            centered: false,
+            content_wide: false,
         }),
     },
 });

--- a/src/modules/content/elements/VideoEmbed/SectionVideoEmbedForm.vue
+++ b/src/modules/content/elements/VideoEmbed/SectionVideoEmbedForm.vue
@@ -1,7 +1,7 @@
 <template>
     <FormFieldLabel>Vimeo-ID</FormFieldLabel>
     <Card class="flex flex-col gap-6">
-        <Toggle v-model="model.centered" label="Content zentrieren" />
+        <Toggle v-model="model.content_wide" label="Ganze Containerbreite" />
         <Input v-model="model.id" label="Vimeo-ID" />
     </Card>
 </template>
@@ -18,7 +18,7 @@ const props = defineProps({
         required: true,
         default: () => ({
             id: '',
-            centered: false,
+            content_wide: false,
         }),
     },
 });

--- a/src/pages/system/SystemUser.vue
+++ b/src/pages/system/SystemUser.vue
@@ -21,13 +21,6 @@
                             v-model="systemUserForm.email"
                             label="E-Mail Adresse"
                         />
-                        <Select
-                            label="Verband"
-                            labelKey="name"
-                            valueKey="id"
-                            v-model="systemUserForm.district_association_id"
-                            :options="districtOptions"
-                        />
                     </FormGroup>
                 </Card>
                 <Card>
@@ -51,12 +44,7 @@
 <script lang="ts" setup>
 import { computed, onBeforeMount, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import {
-    deleteSystemUser,
-    districtAssociationsState,
-    systemUserForm,
-    systemUserState,
-} from '@/entities';
+import { deleteSystemUser, systemUserForm, systemUserState } from '@/entities';
 import { Main, MainBody, MainContent } from '@/layout';
 import SaveButton from '@/modules/save/SaveButton.vue';
 import Topbar from '@/layout/components/Topbar.vue';
@@ -99,19 +87,4 @@ const del = () => {
         });
     }
 };
-
-const districtOptions = computed(() => {
-    let options = districtAssociationsState.value?.map(district => {
-        return {
-            id: district.id,
-            name: district.name,
-        };
-    });
-
-    return [{ id: null, name: 'Landesverband' }, ...options];
-});
-
-onBeforeMount(() => {
-    districtAssociationsState.load();
-});
 </script>


### PR DESCRIPTION
This PR deletes an unnecessary dependency on the system user where the district associations were trying to be loaded but they do not exist in standard admin vue 3 so they caused problems when loading the links.

Also this PR changes the boolean on the content modules from centered content to container width. The content modules will be centered in content width by default and if the toggle is activated, the modules will spread over the entire container width.